### PR TITLE
support for custom user agent

### DIFF
--- a/lib/net/ping/http.rb
+++ b/lib/net/ping/http.rb
@@ -20,7 +20,10 @@ module Net
     # follow a redirect and will return false immediately on a redirect.
     # 
     attr_accessor :follow_redirect
-      
+
+    # Sets the user agent used for the HTTP request to a custom one.
+    attr_accessor :user_agent
+
     # Creates and returns a new Ping::HTTP object.  Note that the default
     # port for Ping::HTTP is 80.
     # 
@@ -53,9 +56,13 @@ module Net
       begin
         response = nil
         uri_path = uri.path.empty? ? '/' : uri.path
-        Timeout.timeout(@timeout){
-          response = Net::HTTP.get_response(uri.host, uri_path, @port)
-        }
+        headers = { }
+        headers["User-Agent"] = user_agent unless user_agent.nil?
+        Timeout.timeout(@timeout) do
+          Net::HTTP.new(uri.host, @port).start do |http|
+            response = http.request_get(uri_path, headers)
+          end
+        end
       rescue Exception => err
         @exception = err.message
       else

--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -108,6 +108,11 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
     assert_nil(@http.warning)
   end
 
+  test 'ping with user agent' do
+    @http.user_agent = "KDDI-CA32"
+    assert_true(@http.ping)
+  end
+
   def teardown
     @uri  = nil
     @http = nil


### PR DESCRIPTION
Added support for a custom user agent for HTTP pings. Would be great if you'd consider adding this. 

Thanks,
Michael
