### PR TITLE
external ping test now also use localhost

### DIFF
--- a/test/test_net_ping_external.rb
+++ b/test/test_net_ping_external.rb
@@ -12,7 +12,7 @@ require 'net/ping/external'
 
 class TC_Net_Ping_External < Test::Unit::TestCase
   def setup
-    @host  = 'www.ruby-lang.org'
+    @host  = 'localhost'
     @bogus = 'foo.bar.baz'
     @pe    = Net::Ping::External.new(@host)
     @bad   = Net::Ping::External.new(@bogus)
@@ -68,7 +68,7 @@ class TC_Net_Ping_External < Test::Unit::TestCase
 
   test "host getter basic functionality" do
     assert_respond_to(@pe, :host)
-    assert_equal('www.ruby-lang.org', @pe.host)
+    assert_equal('localhost', @pe.host)
   end
 
   test "host setter basic functionality" do


### PR DESCRIPTION
Hello,

something changed in our Fedora build servers mock environment and the last test that use www.ruby-lang.org address started failing. I have fixed that. Now everything works only locally except the windows WMI test (which I did not change).

Btw net-ping appeared in Fedora 15. I hope we will fix that and it hits F16 :-)

Thanks.
