### PR TITLE
Fix peer certificate handling in HTTP ping.

### DIFF
--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -163,7 +163,6 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
     assert_equal(443, @http.port)
   end
 
-  # This will generate a warning. Nothing I can do about it.
   test 'ping against https site works as expected' do
     @http = Net::Ping::HTTP.new(@uri_https)
     assert_true(@http.ping)


### PR DESCRIPTION
This patch fixes possible warnings resulting from missing SSL
certificates.

User can now specify the verification mode via @ssl_verify_mode option.
Default is set to VERIFY_NONE, i.e ignore the verification.

Signed-off-by: Balazs Kutil kutil.balazs@gmail.com
