### PR TITLE
Disable resolv-replace for ruby 1.9.3

### DIFF
--- a/lib/net/ping/http.rb
+++ b/lib/net/ping/http.rb
@@ -5,7 +5,7 @@ require 'uri'
 
 # Force non-blocking Socket.getaddrinfo on Unix systems. Do not use on
 # Windows because it (ironically) causes blocking problems.
-unless File::ALT_SEPARATOR
+unless File::ALT_SEPARATOR or RUBY_VERSION >= "1.9.3"
   require 'resolv-replace'
 end
 


### PR DESCRIPTION
@see conflict with spork https://github.com/sporkrb/spork/issues/133

Not sure this should be merged as is, maybe you should investigate further what is the issue with resolv-replace rather than disabling it completely for ruby 1.9.3.

I see this is made for performance purpose, but I think overwriting standard libs should not be made without consent from the gem user (maybe you could a configuration option for this).
