### PR TITLE
Force HTTPS rubygems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'http://rubygems.org'
 gemspec


### PR DESCRIPTION
Symbol :rubygems usage is deprecated with latest bundler.
