### PR TITLE
removed a return of nil from tcp#ping

### DIFF
--- a/lib/net/ping/tcp.rb
+++ b/lib/net/ping/tcp.rb
@@ -45,8 +45,7 @@ module Net
         addr = Socket.getaddrinfo(host, port)
       rescue SocketError => err
         @exception = err
-        bool = false
-        return
+        return false
       end
 
       begin


### PR DESCRIPTION
Net::Ping::TCP's ping method was returning nil in some cases instead of false. Fixed the minor error in the code.
