### PR TITLE
Improve http ping response

### DIFF
--- a/lib/net/ping/http.rb
+++ b/lib/net/ping/http.rb
@@ -116,6 +116,8 @@ module Net
         else
           @exception = response.message
         end
+      else
+        @exception ||= response.message
       end
 
       # There is no duration if the ping failed

--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -26,6 +26,9 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
                          :status => ["302", "Found"])
 
     FakeWeb.register_uri(:any, 'http://www.blabfoobarurghxxxx.com', :exception => SocketError)
+    FakeWeb.register_uri(:head, 'http://http502.com',
+                         :body => "",
+                         :status => ["502", "Bad Gateway"])
 
     @http = Net::Ping::HTTP.new(@uri, 80, 30)
     @bad  = Net::Ping::HTTP.new('http://www.blabfoobarurghxxxx.com') # One hopes not
@@ -166,6 +169,18 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
     @http.redirect_limit  = 0
     assert_false(@http.ping)
     assert_equal("Redirect limit exceeded", @http.exception)
+  end
+
+  test 'http 502 sets exception' do
+    @http = Net::Ping::HTTP.new("http://http502.com")
+    assert_false(@http.ping)
+    assert_equal('Bad Gateway', @http.exception)
+  end
+
+  test 'http 502 sets code' do
+    @http = Net::Ping::HTTP.new("http://http502.com")
+    assert_false(@http.ping)
+    assert_equal('502', @http.code)
   end
 
   test 'ping against https site defaults to port 443' do


### PR DESCRIPTION
This pull request does two things:
1. It is useful to store the http status code returned by a server when it is a client error (4XX) or server error (5XX). This can give insight into why the ping failed.
2. In the above situation (say a server returns a 502), then we should also store this in the exception attribute.

Tests added.
