### PR TITLE
Add travis tests for various ruby versions, with 1.8.7 and jruby marked ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ rvm:
 - 2.1.0
 - rbx
 - 1.8.7
-- jruby-18mode
-- jruby-19mode
+#- jruby-18mode
+#- jruby-19mode
 - jruby-head
 - ruby-head
 matrix:
   allow_failures:
     - rvm: 1.8.7
-    - rvm: jruby-18mode
-    - rvm: jruby-19mode
+    #- rvm: jruby-18mode
+    #- rvm: jruby-19mode
     - rvm: jruby-head
     - rvm: ruby-head


### PR DESCRIPTION
Add travis-ci.org tests for various ruby versions, with 1.8.7 and jruby marked as allowed failures.

This would form the basis for working on enhancements, and fixing or adding comments on readme for unsupported platforms / versions (eg 1.8.7 is currently broken).

(I am thinking on working on thread support for the external ping tests)
