### PR TITLE
Fix a typo in the unit test for Net::Ping::External and change the implementation for Windows

### DIFF
--- a/test/test_net_ping_external.rb
+++ b/test/test_net_ping_external.rb
@@ -128,7 +128,7 @@ class TC_Net_Ping_External < Test::Unit::TestCase
     start_time = Time.now
     @unreachable.ping
     elapsed = Time.now - start_time
-    assert_true(elapsed < @bad.timeout + tolerance)
+    assert_true(elapsed < @unreachable.timeout + tolerance)
   end
 
   def teardown


### PR DESCRIPTION
I had a typo in the test code for timeouts in Net::Ping::External; that was making the test pass even if the timeout wasn't enforced. I reimplemented it using the '-w' option of the Windows version of ping (hoping to avoid thread/process management entirely), and it seems to work now.
