### PR TITLE
-IGNORE- Added count to External system pings

### DIFF
--- a/lib/net/ping/external.rb
+++ b/lib/net/ping/external.rb
@@ -15,7 +15,10 @@ module Net
     # contain a string indicating what went wrong. If the ping succeeded then
     # the Ping::External#warning method may or may not contain a value.
     #
-    def ping(host = @host)
+    def ping(host = @host, count = @count)
+
+      raise "Count must be an integer" unless count.is_a? Integer
+
       super(host)
 
       pcmd = ['ping']
@@ -23,17 +26,17 @@ module Net
 
       case RbConfig::CONFIG['host_os']
         when /linux/i
-          pcmd += ['-c', '1', '-W', @timeout.to_s, host]
+          pcmd += ['-c', count.to_s, '-W', @timeout.to_s, host]
         when /aix/i
-          pcmd += ['-c', '1', '-w', @timeout.to_s, host]
+          pcmd += ['-c', count.to_s, '-w', @timeout.to_s, host]
         when /bsd|osx|mach|darwin/i
-          pcmd += ['-c', '1', '-t', @timeout.to_s, host]
+          pcmd += ['-c', count.to_s, '-t', @timeout.to_s, host]
         when /solaris|sunos/i
           pcmd += [host, @timeout.to_s]
         when /hpux/i
-          pcmd += [host, '-n1', '-m', @timeout.to_s]
+          pcmd += [host, "-n#{count.to_s}", '-m', @timeout.to_s]
         when /win32|windows|msdos|mswin|cygwin|mingw/i
-          pcmd += ['-n', '1', '-w', (@timeout * 1000).to_s, host]
+          pcmd += ['-n', count.to_s, '-w', (@timeout * 1000).to_s, host]
         else
           pcmd += [host]
       end


### PR DESCRIPTION
A simple little change that allows you to specify the number of packets to be sent by the OS when using an External ping.
