### PR TITLE
Add packet count and interval to external pings

### DIFF
--- a/lib/net/ping/external.rb
+++ b/lib/net/ping/external.rb
@@ -15,9 +15,10 @@ module Net
     # contain a string indicating what went wrong. If the ping succeeded then
     # the Ping::External#warning method may or may not contain a value.
     #
-    def ping(host = @host, count = 1, interval = 1)
+    def ping(host = @host, count = 1, interval = 1, timeout = @timeout)
 
       raise "Count must be an integer" unless count.is_a? Integer
+      raise "Timeout must be a number" unless timeout.is_a? Numeric
 
       unless interval.is_a?(Numeric) && interval >= 0.2
         raise "Interval must be a decimal greater than or equal to 0.2"
@@ -30,17 +31,17 @@ module Net
 
       case RbConfig::CONFIG['host_os']
         when /linux/i
-          pcmd += ['-c', count.to_s, '-W', @timeout.to_s, host, '-i', interval.to_s]
+          pcmd += ['-c', count.to_s, '-w', timeout.to_s, host, '-i', interval.to_s]
         when /aix/i
-          pcmd += ['-c', count.to_s, '-w', @timeout.to_s, host]
+          pcmd += ['-c', count.to_s, '-w', timeout.to_s, host]
         when /bsd|osx|mach|darwin/i
-          pcmd += ['-c', count.to_s, '-t', @timeout.to_s, host]
+          pcmd += ['-c', count.to_s, '-t', timeout.to_s, host]
         when /solaris|sunos/i
-          pcmd += [host, @timeout.to_s]
+          pcmd += [host, timeout.to_s]
         when /hpux/i
-          pcmd += [host, "-n#{count.to_s}", '-m', @timeout.to_s]
+          pcmd += [host, "-n#{count.to_s}", '-m', timeout.to_s]
         when /win32|windows|msdos|mswin|cygwin|mingw/i
-          pcmd += ['-n', count.to_s, '-w', (@timeout * 1000).to_s, host]
+          pcmd += ['-n', count.to_s, '-w', (timeout * 1000).to_s, host]
         else
           pcmd += [host]
       end


### PR DESCRIPTION
A simple little change to add support for packet count and intervals for external pings. Unfortunately I don't have a non-linux system to test this on, so only implemented interval for Linux.
